### PR TITLE
Allows selecting group objects as scenes

### DIFF
--- a/ExtensionManifest.json
+++ b/ExtensionManifest.json
@@ -4,7 +4,7 @@
   "author": "Macro Deck",
   "repository": "https://github.com/SuchByte/Macro-Deck-OBS-WebSocket-Plugin",
   "packageId": "SuchByte.OBS-WebSocketPlugin",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "target-plugin-api-version": 40,
   "target-macro-deck-version": "2.13.0",
   "dll": "OBS-WebSocket Plugin.dll"

--- a/Macro-Deck-OBS-WebSocket.csproj
+++ b/Macro-Deck-OBS-WebSocket.csproj
@@ -7,7 +7,7 @@
         <Authors>Macro Deck, RecklessBoon</Authors>
         <Company>Macro Deck</Company>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <Version>2.1.2</Version>
+        <Version>2.1.3</Version>
 	      <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 	      <NeutralLanguage>en</NeutralLanguage>
 	      <PackageProjectUrl>https://github.com/RecklessBoon/Macro-Deck-OBS-WebSocket-Plugin</PackageProjectUrl>

--- a/Main.cs
+++ b/Main.cs
@@ -242,14 +242,23 @@ namespace SuchByte.OBSWebSocketPlugin
             {
                 if (sender is OBSWebSocket obs)
                 {
-                    var sceneItems = await obs.SceneItemsRequests.GetSceneItemListAsync(args.SceneName);
                     var sceneItemName = args.SceneItemId.ToString();
-                    foreach (var item in sceneItems.SceneItems)
+                    var sceneItemsResponse = await obs.SceneItemsRequests.GetSceneItemListAsync(args.SceneName);
+                    var sceneItems = sceneItemsResponse?.SceneItems;
+                    if (sceneItemsResponse == null)
                     {
-                        if (item["sceneItemId"]!.ToString().Equals(args.SceneItemId.ToString()) && item["sourceName"] != null)
+                        var groupSceneItemsResponse = await obs.SceneItemsRequests.GetGroupSceneItemListAsync(args.SceneName);
+                        sceneItems = groupSceneItemsResponse?.SceneItems;
+                    }
+
+                    if ((sceneItems?.Length ?? 0) > 0) {
+                        foreach (var item in sceneItems)
                         {
-                            sceneItemName = item["sourceName"].ToString();
-                            break;
+                            if (item["sceneItemId"]!.ToString().Equals(args.SceneItemId.ToString()) && item["sourceName"] != null)
+                            {
+                                sceneItemName = item["sourceName"].ToString();
+                                break;
+                            }
                         }
                     }
                     connection.SetVariable(args.SceneName + "_" + sceneItemName, args.SceneItemEnabled ? "True" : "False");


### PR DESCRIPTION
Groups act as scenes with OBS and so group items were added to the scene dropdown. Items within a group will then appear in the source items dropdown.

- Also fixes race condition with async tasks adding items to dropdowns